### PR TITLE
Перенос ITrigger в PlatformCore.Infrastructure.Triggers

### DIFF
--- a/Assets/PlatformCore/Infrastructure/Triggers/BaseTrigger.cs
+++ b/Assets/PlatformCore/Infrastructure/Triggers/BaseTrigger.cs
@@ -1,15 +1,18 @@
 using System;
-using _Main.Scripts.SceneOrchestra;
 using UnityEngine;
 
-public class BaseTrigger : MonoBehaviour, ITrigger
+namespace PlatformCore.Infrastructure.Triggers
 {
-	public event Action<string> OnTriggered;
-
-	[SerializeField] private string _triggerId;
-	public string triggerId => _triggerId;
-	public void Trigger()
+	public class BaseTrigger : MonoBehaviour, ITrigger
 	{
-		OnTriggered?.Invoke(triggerId);
+		public event Action<string> OnTriggered;
+
+		[SerializeField] private string _triggerId;
+		public string triggerId => _triggerId;
+
+		public void Trigger()
+		{
+			OnTriggered?.Invoke(triggerId);
+		}
 	}
 }

--- a/Assets/PlatformCore/Infrastructure/Triggers/ITrigger.cs
+++ b/Assets/PlatformCore/Infrastructure/Triggers/ITrigger.cs
@@ -1,12 +1,12 @@
-﻿using System;
+using System;
 
-namespace _Main.Scripts.SceneOrchestra
+namespace PlatformCore.Infrastructure.Triggers
 {
 	public interface ITrigger
 	{
 		event Action<string> OnTriggered;
 		string triggerId { get; }
-		
+
 		void Trigger();
 	}
 }

--- a/Assets/PlatformCore/Infrastructure/Triggers/ZoneTrigger.cs
+++ b/Assets/PlatformCore/Infrastructure/Triggers/ZoneTrigger.cs
@@ -1,10 +1,12 @@
-﻿using UnityEngine;
+using UnityEngine;
 
-public class ZoneTrigger : BaseTrigger
-{ 
-	private void OnTriggerEnter(Collider other)
+namespace PlatformCore.Infrastructure.Triggers
+{
+	public class ZoneTrigger : BaseTrigger
 	{
-		Trigger();
+		private void OnTriggerEnter(Collider other)
+		{
+			Trigger();
+		}
 	}
-	
 }


### PR DESCRIPTION
### Motivation
- Убрать зависимость PlatformCore от `_Main` и разместить контракт триггера в корневом модуле `PlatformCore` с единым namespace.
- Обеспечить, чтобы `BaseTrigger` и `ZoneTrigger` использовали интерфейс из `PlatformCore` без `using _Main.Scripts.SceneOrchestra`.

### Description
- Перенёс интерфейс в `Assets/PlatformCore/Infrastructure/Triggers/ITrigger.cs` и изменил его namespace на `PlatformCore.Infrastructure.Triggers`.
- Обновил `Assets/PlatformCore/Infrastructure/Triggers/BaseTrigger.cs` чтобы класс был в `PlatformCore.Infrastructure.Triggers` и реализовывал новый `ITrigger` без `using _Main.Scripts.SceneOrchestra`.
- Обновил `Assets/PlatformCore/Infrastructure/Triggers/ZoneTrigger.cs` чтобы класс находился в `PlatformCore.Infrastructure.Triggers` и корректно наследовал `BaseTrigger`.
- Выполнен коммит изменений в репозиторий (изменены три файла в `Assets/PlatformCore/Infrastructure/Triggers`).

### Testing
- Выполнен поиск `rg -n "namespace PlatformCore\.Infrastructure\.Triggers|class BaseTrigger|class ZoneTrigger|interface ITrigger" Assets/PlatformCore/Infrastructure/Triggers/*.cs` и подтверждена корректная декларация новых namespace и типов (успех).
- Выполнен поиск `rg -n "_Main\." Assets/PlatformCore --glob '*.{cs,asmdef,asmref,md,txt,yml,yaml,json,xml,csproj}'` и подтверждено, что в `Assets/PlatformCore` больше нет ссылок на `_Main` (успех).
- Выполнен поиск `rg -n "_Main\.Scripts\.SceneOrchestra|\bITrigger\b" Assets --glob '*.cs'` чтобы убедиться, что объявления `ITrigger` присутствуют только в PlatformCore (успех).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a882c91c832dae138190bc00576f)