### PR TITLE
Introduce PlatformCore.Services namespace and move trigger types into PlatformCore.Infrastructure.Triggers

### DIFF
--- a/Assets/PlatformCore/Infrastructure/Lifecycle/LifecycleService.cs
+++ b/Assets/PlatformCore/Infrastructure/Lifecycle/LifecycleService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
 using PlatformCore.Core;
+using PlatformCore.Services;
 
 namespace PlatformCore.Infrastructure.Lifecycle
 {

--- a/Assets/PlatformCore/Infrastructure/Triggers/BaseTrigger.cs
+++ b/Assets/PlatformCore/Infrastructure/Triggers/BaseTrigger.cs
@@ -1,15 +1,18 @@
 using System;
-using _Main.Scripts.SceneOrchestra;
 using UnityEngine;
 
-public class BaseTrigger : MonoBehaviour, ITrigger
+namespace PlatformCore.Infrastructure.Triggers
 {
-	public event Action<string> OnTriggered;
-
-	[SerializeField] private string _triggerId;
-	public string triggerId => _triggerId;
-	public void Trigger()
+	public class BaseTrigger : MonoBehaviour, ITrigger
 	{
-		OnTriggered?.Invoke(triggerId);
+		public event Action<string> OnTriggered;
+
+		[SerializeField] private string _triggerId;
+		public string triggerId => _triggerId;
+
+		public void Trigger()
+		{
+			OnTriggered?.Invoke(triggerId);
+		}
 	}
 }

--- a/Assets/PlatformCore/Infrastructure/Triggers/ITrigger.cs
+++ b/Assets/PlatformCore/Infrastructure/Triggers/ITrigger.cs
@@ -1,12 +1,12 @@
-﻿using System;
+using System;
 
-namespace _Main.Scripts.SceneOrchestra
+namespace PlatformCore.Infrastructure.Triggers
 {
 	public interface ITrigger
 	{
 		event Action<string> OnTriggered;
 		string triggerId { get; }
-		
+
 		void Trigger();
 	}
 }

--- a/Assets/PlatformCore/Infrastructure/Triggers/ZoneTrigger.cs
+++ b/Assets/PlatformCore/Infrastructure/Triggers/ZoneTrigger.cs
@@ -1,10 +1,12 @@
-﻿using UnityEngine;
+using UnityEngine;
 
-public class ZoneTrigger : BaseTrigger
-{ 
-	private void OnTriggerEnter(Collider other)
+namespace PlatformCore.Infrastructure.Triggers
+{
+	public class ZoneTrigger : BaseTrigger
 	{
-		Trigger();
+		private void OnTriggerEnter(Collider other)
+		{
+			Trigger();
+		}
 	}
-	
 }

--- a/Assets/PlatformCore/Services/BaseAsyncService.cs
+++ b/Assets/PlatformCore/Services/BaseAsyncService.cs
@@ -1,13 +1,16 @@
-﻿using System.Threading;
+using System.Threading;
 using Cysharp.Threading.Tasks;
 
-public abstract class BaseAsyncService : IAsyncInitializable
+namespace PlatformCore.Services
 {
-	protected virtual UniTask OnPreInitializeAsync(CancellationToken ct) => UniTask.CompletedTask;
-	protected virtual UniTask OnPostInitializeAsync(CancellationToken ct) => UniTask.CompletedTask;
+	public abstract class BaseAsyncService : IAsyncInitializable
+	{
+		protected virtual UniTask OnPreInitializeAsync(CancellationToken ct) => UniTask.CompletedTask;
+		protected virtual UniTask OnPostInitializeAsync(CancellationToken ct) => UniTask.CompletedTask;
 
-	public async UniTask PreInitializeAsync(CancellationToken ct) => await OnPreInitializeAsync(ct);
-	public async UniTask PostInitializeAsync(CancellationToken ct) => await OnPostInitializeAsync(ct);
+		public async UniTask PreInitializeAsync(CancellationToken ct) => await OnPreInitializeAsync(ct);
+		public async UniTask PostInitializeAsync(CancellationToken ct) => await OnPostInitializeAsync(ct);
 
-	public virtual void Dispose() { }
+		public virtual void Dispose() { }
+	}
 }

--- a/Assets/PlatformCore/Services/Factory/ObjectFactory.cs
+++ b/Assets/PlatformCore/Services/Factory/ObjectFactory.cs
@@ -1,7 +1,7 @@
 ﻿using Cysharp.Threading.Tasks;
 using UnityEngine;
 
-namespace PlatformCore.Services.Factory.PlatformCore.Services.Factory
+namespace PlatformCore.Services.Factory
 {
 	public class ObjectFactory : BaseAsyncService, IObjectFactory
 	{

--- a/Assets/PlatformCore/Services/IService.cs
+++ b/Assets/PlatformCore/Services/IService.cs
@@ -2,17 +2,20 @@ using System;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 
-public interface IService : IDisposable
+namespace PlatformCore.Services
 {
-}
+	public interface IService : IDisposable
+	{
+	}
 
-public interface IAsyncInitializable : IService
-{
-	UniTask PreInitializeAsync(CancellationToken ct);
-	UniTask PostInitializeAsync(CancellationToken ct);
-}
+	public interface IAsyncInitializable : IService
+	{
+		UniTask PreInitializeAsync(CancellationToken ct);
+		UniTask PostInitializeAsync(CancellationToken ct);
+	}
 
-public interface ISyncInitializable : IService
-{
-	void Initialize();
+	public interface ISyncInitializable : IService
+	{
+		void Initialize();
+	}
 }

--- a/Assets/PlatformCore/Services/ServiceLocator.cs
+++ b/Assets/PlatformCore/Services/ServiceLocator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using PlatformCore.Services;
 
 namespace PlatformCore.Core
 {

--- a/Assets/PlatformCore/Services/ServiceLocatorExtensions.cs
+++ b/Assets/PlatformCore/Services/ServiceLocatorExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using PlatformCore.Services;
 
 namespace PlatformCore.Core
 {

--- a/Assets/_Main/Scripts/Core/GameRoot.cs
+++ b/Assets/_Main/Scripts/Core/GameRoot.cs
@@ -8,7 +8,6 @@ using PlatformCore.Core;
 using PlatformCore.Services;
 using PlatformCore.Services.Audio;
 using PlatformCore.Services.Factory;
-using PlatformCore.Services.Factory.PlatformCore.Services.Factory;
 using PlatformCore.Services.UI;
 using UnityEngine;
 

--- a/Assets/_Main/Scripts/Core/Services/InputBaseService.cs
+++ b/Assets/_Main/Scripts/Core/Services/InputBaseService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using PlatformCore.Services;
 using UnityEngine;
 
 namespace _Main.Scripts.Core.Services

--- a/Assets/_Main/Scripts/Localization/LocalizationServiceBase.cs
+++ b/Assets/_Main/Scripts/Localization/LocalizationServiceBase.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using PlatformCore.Services.Factory;
+using PlatformCore.Services;
 
 public class LocalizationServiceBase : BaseAsyncService, ILocalizationService
 {

--- a/Assets/_Main/Scripts/Notifications/GlobalNotificationService.cs
+++ b/Assets/_Main/Scripts/Notifications/GlobalNotificationService.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
 using PlatformCore.Services.Factory;
 using PlatformCore.Services.UI;
+using PlatformCore.Services;
 
 public class GlobalNotificationService : BaseAsyncService
 {


### PR DESCRIPTION
### Motivation
- Consolidate service-related interfaces and base classes under a dedicated `PlatformCore.Services` namespace to improve organization and resolve type references.
- Fix incorrect/duplicate namespaces (e.g. `ObjectFactory`) and update references across the codebase to match the new layout.
- Place trigger-related types into `PlatformCore.Infrastructure.Triggers` to group trigger implementations and interfaces logically.

### Description
- Added `PlatformCore.Services` namespace and moved/declared `IService`, `IAsyncInitializable`, `ISyncInitializable`, and `BaseAsyncService` into it, updating the class definitions accordingly.
- Updated `ObjectFactory` namespace to `PlatformCore.Services.Factory` and adjusted usages where necessary.
- Updated multiple files to `using PlatformCore.Services;` and adjusted code to reference the new service interfaces and base classes (including `LifecycleService`, `ServiceLocator`, `ServiceLocatorExtensions`, `InputBaseService`, `LocalizationServiceBase`, `GlobalNotificationService`, and others).
- Introduced `PlatformCore.Infrastructure.Triggers` namespace and moved `ITrigger`, `BaseTrigger`, and `ZoneTrigger` into it with minor fixes to `Trigger()` invocation and event handling.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a34b8840832db38bd396d5a9f610)