### PR TITLE
Separate AI and Player: Modifiers, Items, Scoring | 129

### DIFF
--- a/Assets/Resources/Json/dice_game_rules.json
+++ b/Assets/Resources/Json/dice_game_rules.json
@@ -2,6 +2,7 @@
   {
     "id": "default",
     "target_score": 2000,
-    "min_bet_size": 10
+    "min_bet_size": 10,
+    "enemy_combo_upgrades_enabled": true
   }
 ]

--- a/Assets/_Main/Scripts/Configs/DiceGameConfig.cs
+++ b/Assets/_Main/Scripts/Configs/DiceGameConfig.cs
@@ -6,4 +6,5 @@ public class DiceGameConfig : BaseConfig
 	public int target_score;
 	public int max_turn_count;
 	public int min_bet_size;
+	public bool enemy_combo_upgrades_enabled = true;
 }

--- a/Assets/_Main/Scripts/Core/GameRoot.cs
+++ b/Assets/_Main/Scripts/Core/GameRoot.cs
@@ -78,7 +78,7 @@ namespace _Main.Scripts.Core
 			// --------------
 
 			var playerModel = new PlayerModel();
-			var diceGameModel = new DiceGameModel(playerModel.InventoryModel);
+			var diceGameModel = new DiceGameModel(playerModel.InventoryModel, scoringService);
 
 			// persistent scene load
 			var persistentSceneName = sceneService.GetActiveSceneName();

--- a/Assets/_Main/Scripts/DiceGame/EnemyTurnController.cs
+++ b/Assets/_Main/Scripts/DiceGame/EnemyTurnController.cs
@@ -10,7 +10,6 @@ public class EnemyTurnController : IBaseController, IActivatable
 {
 	private readonly DiceGameProcessController processController;
 	private readonly DiceGameModel diceGameModel;
-	private readonly DiceScoringService scoringService;
 	private TableModel tableModel => diceGameModel.tableModel;
 
 	private int delay => Mathf.Max(1, Mathf.RoundToInt(GlobalParameters.Delay * GlobalParameters.EnemyTurnDelayMultiplier));
@@ -19,12 +18,10 @@ public class EnemyTurnController : IBaseController, IActivatable
 
 	public EnemyTurnController(
 		DiceGameProcessController processController,
-		DiceGameModel diceGameModel,
-		DiceScoringService scoringService)
+		DiceGameModel diceGameModel)
 	{
 		this.processController = processController;
 		this.diceGameModel = diceGameModel;
-		this.scoringService = scoringService;
 	}
 
 	public void Activate()
@@ -83,14 +80,15 @@ public class EnemyTurnController : IBaseController, IActivatable
 				}
 
 				int[] values = DiceGameUtils.GetDiceValues(unbanked);
-				var combinations = scoringService.Evaluate(values);
+				var activeScoringService = diceGameModel.GetCurrentScoringService();
+				var combinations = activeScoringService.Evaluate(values);
 				if (combinations.Combinations.Count == 0)
 				{
 					await UniTask.Delay(delay);
 					return;
 				}
 
-				int bestMask = FindBestMask(values);
+				int bestMask = FindBestMask(values, activeScoringService);
 
 				for (int i = 0; i < unbanked.Length; i++)
 				{
@@ -153,7 +151,7 @@ public class EnemyTurnController : IBaseController, IActivatable
 		await processController.HandleRollAsync();
 	}
 
-	private int FindBestMask(int[] values)
+	private int FindBestMask(int[] values, DiceScoringService scoringService)
 	{
 		int bestScore = -1;
 		int bestMask = 0;

--- a/Assets/_Main/Scripts/DiceGame/EnemyTurnController.cs
+++ b/Assets/_Main/Scripts/DiceGame/EnemyTurnController.cs
@@ -74,7 +74,7 @@ public class EnemyTurnController : IBaseController, IActivatable
 
 				if (unbanked.Length == 0)
 				{
-					processController.EndTurn(true);
+					await Pass();
 					await UniTask.Delay(delay);
 					return;
 				}
@@ -106,7 +106,7 @@ public class EnemyTurnController : IBaseController, IActivatable
 				// если можно уже выиграть — пасуем
 				if (tableModel.EnemyBankedPoints + tableModel.TurnPoints >= diceGameModel.TargetPoints)
 				{
-					processController.EndTurn(true);
+					await Pass();
 					await UniTask.Delay(delay);
 					return;
 				}
@@ -114,7 +114,7 @@ public class EnemyTurnController : IBaseController, IActivatable
 				// если уже набрали нормально — пас
 				if (tableModel.TurnPoints >= 400)
 				{
-					processController.EndTurn(true);
+					await Pass();
 					await UniTask.Delay(delay);
 					return;
 				}
@@ -127,7 +127,7 @@ public class EnemyTurnController : IBaseController, IActivatable
 				}
 				else
 				{
-					processController.EndTurn(true);
+					await Pass();
 					await UniTask.Delay(delay);
 					return;
 				}
@@ -149,6 +149,16 @@ public class EnemyTurnController : IBaseController, IActivatable
 		}
 
 		await processController.HandleRollAsync();
+	}
+
+	private async UniTask Pass()
+	{
+		if (processController.IsProcessing)
+		{
+			return;
+		}
+
+		await processController.HandlePassForCurrentTurnAsync();
 	}
 
 	private int FindBestMask(int[] values, DiceScoringService scoringService)

--- a/Assets/_Main/Scripts/DiceGame/Items/Examples/ExtraDiceCapItem.cs
+++ b/Assets/_Main/Scripts/DiceGame/Items/Examples/ExtraDiceCapItem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace _Main.Scripts.Dice
 		private readonly DiceItemView customPrefab;
 		private DiceGameModel boundGameModel;
 		private readonly string bonusKey;
+		private bool boundIsPlayerSide = true;
 
 		public ExtraDiceCapItem(string id, int bonus = 4, DiceItemView prefabOverride = null)
 			: base(id, id, DiceItemActivationType.Passive)
@@ -40,14 +42,14 @@ namespace _Main.Scripts.Dice
 
 		public void OnRemovedFromGameModel(DiceGameModel gameModel)
 		{
-			gameModel?.RemoveDiceCapModifier(bonusKey);
+			gameModel?.RemoveDiceCapModifier(bonusKey, boundIsPlayerSide);
 			boundGameModel = null;
 		}
 
 		public override void ResetItem()
 		{
 			base.ResetItem();
-			boundGameModel?.RemoveDiceCapModifier(bonusKey);
+			boundGameModel?.RemoveDiceCapModifier(bonusKey, boundIsPlayerSide);
 			boundGameModel = null;
 		}
 
@@ -61,7 +63,23 @@ namespace _Main.Scripts.Dice
 			}
 
 			boundGameModel = gameModel;
-			boundGameModel.SetDiceCapModifier(bonusKey, bonus);
+			boundIsPlayerSide = ResolveBoundSide(gameModel);
+			boundGameModel.SetDiceCapModifier(bonusKey, bonus, boundIsPlayerSide);
+		}
+
+		private bool ResolveBoundSide(DiceGameModel gameModel)
+		{
+			if (gameModel.PlayerModifierItemsModel.Items.Contains(this))
+			{
+				return true;
+			}
+
+			if (gameModel.EnemyModifierItemsModel.Items.Contains(this))
+			{
+				return false;
+			}
+
+			return gameModel.IsPlayerTurn;
 		}
 	}
 }

--- a/Assets/_Main/Scripts/DiceGame/Models/DiceGameModel.cs
+++ b/Assets/_Main/Scripts/DiceGame/Models/DiceGameModel.cs
@@ -372,10 +372,19 @@ namespace _Main.Scripts.Dice
 			tableModel.Reset();
 			PlayerDiceModelList.Clear();
 			EnemyDiceModelList.Clear();
+			ResetEnemyRuntime();
 			DiceGameState = DiceGameState.DEFAULT;
 			IsDiceGameStarted = false;
 			IsConditionPassed = false;
 			CurrentTurn = 0;
+		}
+
+		private void ResetEnemyRuntime()
+		{
+			EnemyModifierItemsModel.Reset();
+			EnemyModifiersModel.Reset();
+			enemyDiceCapBonuses.Clear();
+			EnemyScoringService.ResetUpgradeStatesToDefaults();
 		}
 	}
 }

--- a/Assets/_Main/Scripts/DiceGame/Models/DiceGameModel.cs
+++ b/Assets/_Main/Scripts/DiceGame/Models/DiceGameModel.cs
@@ -20,8 +20,15 @@ namespace _Main.Scripts.Dice
 		public event Action OnPassClicked;
 		
 		public TableModel tableModel;
-		public ModifiersModel ModifiersModel;
-		public ModifierItemsModel ModifierItemsModel;
+		public ModifiersModel PlayerModifiersModel { get; }
+		public ModifiersModel EnemyModifiersModel { get; }
+		public ModifierItemsModel PlayerModifierItemsModel { get; }
+		public ModifierItemsModel EnemyModifierItemsModel { get; }
+		public DiceScoringService PlayerScoringService { get; }
+		public DiceScoringService EnemyScoringService { get; }
+
+		public ModifiersModel ModifiersModel => GetCurrentModifiersModel();
+		public ModifierItemsModel ModifierItemsModel => GetCurrentModifierItemsModel();
 		
 		public List<DiceModel> CurrentDiceModelList => IsPlayerTurn ? PlayerDiceModelList : EnemyDiceModelList;
 		
@@ -40,18 +47,30 @@ namespace _Main.Scripts.Dice
 		public int TargetPoints { get; private set; }
 		public bool IsConditionPassed { get; private set; }
 		public bool IsDiceGameStarted { get; private set; }
-		public int MaxDiceCount => Mathf.Max(1, baseMaxDiceCount + GetDiceCapBonusSum());
+		public bool EnemyComboUpgradesEnabled { get; private set; } = true;
+		public int MaxDiceCount => Mathf.Max(1, baseMaxDiceCount + GetDiceCapBonusSum(IsPlayerTurn));
 		public int BaseMaxDiceCount => baseMaxDiceCount;
 
 		private const int DefaultMaxDiceCount = 6;
 		private int baseMaxDiceCount = DefaultMaxDiceCount;
-		private readonly Dictionary<string, int> diceCapBonuses = new();
+		private readonly Dictionary<string, int> playerDiceCapBonuses = new();
+		private readonly Dictionary<string, int> enemyDiceCapBonuses = new();
 
-		public DiceGameModel(InventoryModel inventoryModel)
+		public DiceGameModel(
+			InventoryModel inventoryModel,
+			DiceScoringService playerScoringService = null,
+			DiceScoringService enemyScoringService = null)
 		{
-			ModifiersModel = inventoryModel?.ModifiersModel ?? new ModifiersModel();
-			ModifierItemsModel = inventoryModel?.ModifierItemsModel ?? new ModifierItemsModel(ModifiersModel);
-			ModifierItemsModel.BindGameModel(this);
+			PlayerModifiersModel = inventoryModel?.ModifiersModel ?? new ModifiersModel();
+			PlayerModifierItemsModel = inventoryModel?.ModifierItemsModel ?? new ModifierItemsModel(PlayerModifiersModel);
+			PlayerModifierItemsModel.BindGameModel(this);
+
+			EnemyModifiersModel = new ModifiersModel();
+			EnemyModifierItemsModel = new ModifierItemsModel(EnemyModifiersModel);
+			EnemyModifierItemsModel.BindGameModel(this);
+
+			PlayerScoringService = playerScoringService ?? new DiceScoringService();
+			EnemyScoringService = enemyScoringService ?? new DiceScoringService();
 		}
 		
 		public void Setup(DiceGameConfig diceGameConfig, int maxBetSize, TableModel tableModel)
@@ -61,6 +80,7 @@ namespace _Main.Scripts.Dice
 			SetMaxBetSize(maxBetSize);
 			SetBetSize((diceGameConfig.min_bet_size + maxBetSize) / 2);
 			SetTargetScore(diceGameConfig.target_score);
+			EnemyComboUpgradesEnabled = diceGameConfig.enemy_combo_upgrades_enabled;
 			SetCurrentTurn(1, true);
 		}
 
@@ -81,6 +101,11 @@ namespace _Main.Scripts.Dice
 		/// </summary>
 		public void SetDiceCapModifier(string sourceId, int bonus)
 		{
+			SetDiceCapModifier(sourceId, bonus, IsPlayerTurn);
+		}
+
+		public void SetDiceCapModifier(string sourceId, int bonus, bool isPlayerSide)
+		{
 			if (string.IsNullOrWhiteSpace(sourceId))
 			{
 				return;
@@ -88,11 +113,16 @@ namespace _Main.Scripts.Dice
 
 			bonus = Mathf.Max(0, bonus);
 			var old = MaxDiceCount;
-			diceCapBonuses[sourceId] = bonus;
+			GetDiceCapBonuses(isPlayerSide)[sourceId] = bonus;
 			NotifyMaxDiceChanged(old);
 		}
 
 		public void RemoveDiceCapModifier(string sourceId)
+		{
+			RemoveDiceCapModifier(sourceId, IsPlayerTurn);
+		}
+
+		public void RemoveDiceCapModifier(string sourceId, bool isPlayerSide)
 		{
 			if (string.IsNullOrWhiteSpace(sourceId))
 			{
@@ -100,20 +130,55 @@ namespace _Main.Scripts.Dice
 			}
 
 			var old = MaxDiceCount;
-			if (diceCapBonuses.Remove(sourceId))
+			if (GetDiceCapBonuses(isPlayerSide).Remove(sourceId))
 			{
 				NotifyMaxDiceChanged(old);
 			}
 		}
 
-		private int GetDiceCapBonusSum()
+		public ModifiersModel GetCurrentModifiersModel()
+		{
+			return IsPlayerTurn ? PlayerModifiersModel : EnemyModifiersModel;
+		}
+
+		public ModifiersModel GetModifiersModel(bool isPlayerSide)
+		{
+			return isPlayerSide ? PlayerModifiersModel : EnemyModifiersModel;
+		}
+
+		public ModifierItemsModel GetCurrentModifierItemsModel()
+		{
+			return IsPlayerTurn ? PlayerModifierItemsModel : EnemyModifierItemsModel;
+		}
+
+		public ModifierItemsModel GetModifierItemsModel(bool isPlayerSide)
+		{
+			return isPlayerSide ? PlayerModifierItemsModel : EnemyModifierItemsModel;
+		}
+
+		public DiceScoringService GetCurrentScoringService()
+		{
+			return IsPlayerTurn ? PlayerScoringService : EnemyScoringService;
+		}
+
+		public DiceScoringService GetScoringService(bool isPlayerSide)
+		{
+			return isPlayerSide ? PlayerScoringService : EnemyScoringService;
+		}
+
+		private int GetDiceCapBonusSum(bool isPlayerSide)
 		{
 			var sum = 0;
-			foreach (var bonus in diceCapBonuses.Values)
+			foreach (var bonus in GetDiceCapBonuses(isPlayerSide).Values)
 			{
 				sum += bonus;
 			}
 			return sum;
+		}
+
+		private Dictionary<string, int> GetDiceCapBonuses(bool isPlayerSide)
+		{
+			return isPlayerSide ? playerDiceCapBonuses : enemyDiceCapBonuses;
 		}
 
 		private void NotifyMaxDiceChanged(int previous)

--- a/Assets/_Main/Scripts/DiceGame/Modifiers/LevelStartModifierController.cs
+++ b/Assets/_Main/Scripts/DiceGame/Modifiers/LevelStartModifierController.cs
@@ -40,7 +40,7 @@ namespace _Main.Scripts.Dice
 				run);
 
 			// Fire and forget; LevelStart modifiers are expected to be quick.
-			diceGameModel.ModifiersModel.PlayLevelStartActions(context).Forget();
+			diceGameModel.PlayerModifiersModel.PlayLevelStartActions(context).Forget();
 		}
 	}
 }

--- a/Assets/_Main/Scripts/DiceGame/Modifiers/ModifiersModel.cs
+++ b/Assets/_Main/Scripts/DiceGame/Modifiers/ModifiersModel.cs
@@ -94,7 +94,6 @@ namespace _Main.Scripts.Dice
 			for (int i = allModifiers.Count - 1; i >= 0; i--)
 			{
 				RemoveModifier(allModifiers[i]);
-				allModifiers.RemoveAt(i);
 			}
 		}
 
@@ -145,6 +144,7 @@ namespace _Main.Scripts.Dice
 
 		public void Reset()
 		{
+			allModifiers.Clear();
 			onLevelStartActionsHandler.Clear();
 			onRoundStartActionsHandler.Clear();
 			onRollActionsHandler.Clear();

--- a/Assets/_Main/Scripts/DiceGame/Scoring/DiceScoringService.cs
+++ b/Assets/_Main/Scripts/DiceGame/Scoring/DiceScoringService.cs
@@ -282,6 +282,12 @@ namespace _Main.Scripts.Dice
 			straightCombination.ResetToDefaults(straightConfig?.Defaults);
 		}
 
+		public void ResetUpgradeStatesToDefaults()
+		{
+			ResetStraightToDefaults();
+			InitializeDefaultUpgradeStates();
+		}
+
 		public void Dispose()
 		{
 		}

--- a/Assets/_Main/Scripts/DiceGame/Сontrollers/DiceGameGlobalController.cs
+++ b/Assets/_Main/Scripts/DiceGame/Сontrollers/DiceGameGlobalController.cs
@@ -27,7 +27,6 @@ namespace _Main.Scripts.Dice
 		private readonly ConfigService configService;
 		private readonly IUIService uiService;
 		private readonly IInputService inputService;
-		private readonly DiceScoringService scoringService;
 
 		private readonly SceneContext sceneContext;
 
@@ -63,7 +62,6 @@ namespace _Main.Scripts.Dice
 			audioService = serviceLocator.Get<IAudioService>();
 			uiService = serviceLocator.Get<IUIService>();
 			inputService = serviceLocator.Get<IInputService>();
-			scoringService = serviceLocator.Get<DiceScoringService>();
 		}
 
 		public void Activate()
@@ -134,12 +132,12 @@ namespace _Main.Scripts.Dice
 			await SetupEnemyDiceList();
 
 			var processController = new DiceGameProcessController(
-				loggerService, diceGameModel, cameraShakeService, audioService, scoringService, run, notificationService);
+				loggerService, diceGameModel, cameraShakeService, audioService, run, notificationService);
 
 			gameControllers.AddRange(new IBaseController[]
 			{
 				processController,
-				new EnemyTurnController(processController, diceGameModel, scoringService),
+				new EnemyTurnController(processController, diceGameModel),
 				new DiceGameViewController(sceneContext.DiceGameTableView, diceGameModel, cameraShakeService, notificationService),
 				new DiceGameResultController(diceGameModel)
 			});
@@ -347,7 +345,7 @@ namespace _Main.Scripts.Dice
 
 		private async UniTask SetupItemsDisplay()
 		{
-			var items = diceGameModel.ModifierItemsModel.Items;
+			var items = diceGameModel.PlayerModifierItemsModel.Items;
 			if (items.Count == 0)
 			{
 				return;

--- a/Assets/_Main/Scripts/DiceGame/Сontrollers/DiceGameProcessController.cs
+++ b/Assets/_Main/Scripts/DiceGame/Сontrollers/DiceGameProcessController.cs
@@ -23,7 +23,6 @@ namespace _Main.Scripts.Dice
 		private readonly DiceGameModel diceGameModel;
 		private readonly Run run;
 		private readonly GlobalNotificationService notificationService;
-		private readonly DiceScoringService scoringService;
 		private TableModel tableModel => diceGameModel.tableModel;
 
 		public bool IsProcessing { get; private set; }
@@ -33,7 +32,6 @@ namespace _Main.Scripts.Dice
 			DiceGameModel diceGameModel,
 			ICameraShakeService cameraShakeService,
 			IAudioService audioService,
-			DiceScoringService scoringService,
 			Run run,
 			GlobalNotificationService notificationService)
 		{
@@ -41,7 +39,6 @@ namespace _Main.Scripts.Dice
 			this.diceGameModel = diceGameModel;
 			this.cameraShakeService = cameraShakeService;
 			this.audioService = audioService;
-			this.scoringService = scoringService;
 			this.run = run;
 			this.notificationService = notificationService;
 		}
@@ -110,14 +107,17 @@ namespace _Main.Scripts.Dice
 						diceGameModel,
 						ModifierStage.RoundStart,
 						run);
-					await diceGameModel.ModifiersModel.PlayRoundStartActions(roundStartContext);
+					await diceGameModel.GetCurrentModifiersModel().PlayRoundStartActions(roundStartContext);
 
 					tableModel.isFirstRoll = false;
 					diceGameModel.ShowAllDiceGameModels();
 				}
 				
-	
-				bool isHotDice = await TrySaveSelected(diceGameModel.GetSelected(), scoringService.Evaluate(GetValues(diceGameModel.GetSelected())));
+
+				var activeScoringService = diceGameModel.GetCurrentScoringService();
+				bool isHotDice = await TrySaveSelected(
+					diceGameModel.GetSelected(),
+					activeScoringService.Evaluate(GetValues(diceGameModel.GetSelected())));
 				tableModel.SetPreviewPoints(0);
 
 				// Если все кубы забанкированы после сохранения, сбросить пул
@@ -146,7 +146,7 @@ namespace _Main.Scripts.Dice
 
 				await UniTask.Delay(GlobalParameters.Delay / 2);
 				
-				var diceCombinationResult = scoringService.Evaluate(GetValues(diceToRoll));
+				var diceCombinationResult = activeScoringService.Evaluate(GetValues(diceToRoll));
 				var rollModifierContext = new DiceModifierContext(
 					diceCombinationResult,
 					diceToRoll,
@@ -155,7 +155,7 @@ namespace _Main.Scripts.Dice
 					ModifierStage.Roll,
 					run);
 
-				await diceGameModel.ModifiersModel.PlayRollActions(rollModifierContext);
+				await diceGameModel.GetCurrentModifiersModel().PlayRollActions(rollModifierContext);
 
 				if (diceCombinationResult.Combinations.Count == 0)
 				{
@@ -172,7 +172,7 @@ namespace _Main.Scripts.Dice
 						diceGameModel,
 						ModifierStage.RoundEnd,
 						run);
-					await diceGameModel.ModifiersModel.PlayRoundEndActions(roundEndContext);
+					await diceGameModel.GetCurrentModifiersModel().PlayRoundEndActions(roundEndContext);
 					EndTurn(false);
 				}
 			}
@@ -209,7 +209,8 @@ namespace _Main.Scripts.Dice
 				diceGameModel.tableModel.DisableButtons();
 				
 				var selected = diceGameModel.GetSelected();
-				var combo = scoringService.Evaluate(GetValues(selected));
+				var activeScoringService = diceGameModel.GetCurrentScoringService();
+				var combo = activeScoringService.Evaluate(GetValues(selected));
 				var passModifierContext = new DiceModifierContext(
 					combo,
 					selected,
@@ -217,7 +218,7 @@ namespace _Main.Scripts.Dice
 					diceGameModel,
 					ModifierStage.Pass,
 					run);
-				await diceGameModel.ModifiersModel.PlayPassActions(passModifierContext);
+				await diceGameModel.GetCurrentModifiersModel().PlayPassActions(passModifierContext);
 				await TrySaveSelected(selected, passModifierContext.CombinationResult);
 				var roundEndContext = new DiceModifierContext(
 					passModifierContext.CombinationResult,
@@ -226,7 +227,7 @@ namespace _Main.Scripts.Dice
 					diceGameModel,
 					ModifierStage.RoundEnd,
 					run);
-				await diceGameModel.ModifiersModel.PlayRoundEndActions(roundEndContext);
+				await diceGameModel.GetCurrentModifiersModel().PlayRoundEndActions(roundEndContext);
 				EndTurn(true);
 			}
 			finally
@@ -246,7 +247,8 @@ namespace _Main.Scripts.Dice
 
 		public async UniTask<bool> TrySaveSelected(DiceModel[] selected, DiceCombinationResult combinationResult)
 		{
-			int points = scoringService.CalculateTotalScore(combinationResult);
+			var activeScoringService = diceGameModel.GetCurrentScoringService();
+			int points = activeScoringService.CalculateTotalScore(combinationResult);
 			if (points <= 0)
 			{
 				return false;
@@ -300,10 +302,9 @@ namespace _Main.Scripts.Dice
 			       || combination == DiceCombination.StraightLength6;
 		}
 
-		private DiceModel PickUpgradeDie(StraightUpgradeConfig upgradeConfig)
+		private DiceModel PickUpgradeDie()
 		{
-			// MVP: choose randomly from currently equipped player dice (Option A).
-			var pool = diceGameModel.PlayerDiceModelList;
+			var pool = diceGameModel.CurrentDiceModelList;
 			if (pool == null || pool.Count == 0)
 			{
 				return null;
@@ -473,24 +474,31 @@ namespace _Main.Scripts.Dice
 				return;
 			}
 
+			if (!diceGameModel.IsPlayerTurn && !diceGameModel.EnemyComboUpgradesEnabled)
+			{
+				return;
+			}
+
+			var activeScoringService = diceGameModel.GetCurrentScoringService();
+
 			// 1) Straight first
-			var straightConfig = scoringService.GetStraightUpgradeConfig();
+			var straightConfig = activeScoringService.GetStraightUpgradeConfig();
 			if (straightConfig != null && straightConfig.Chance > 0f && combinationResult.Combinations.Any(e => IsStraightCombination(e.Combination)))
 			{
-				await HandleStraightUpgrade(straightConfig);
+				await HandleStraightUpgrade(straightConfig, activeScoringService);
 				return;
 			}
 
 			// 2) Of-a-kind
-			var ofaConfig = scoringService.GetComboUpgradeConfig("ofakind");
+			var ofaConfig = activeScoringService.GetComboUpgradeConfig("ofakind");
 			if (ofaConfig != null && ofaConfig.Chance > 0f && combinationResult.Combinations.Any(e => e.Combination == DiceCombination.ThreeOfAKind || e.Combination == DiceCombination.FourOfAKind || e.Combination == DiceCombination.FiveOfAKind || e.Combination == DiceCombination.SixOfAKind))
 			{
-				await HandleUpgradeForCombo("ofakind", ofaConfig);
+				await HandleUpgradeForCombo("ofakind", ofaConfig, activeScoringService);
 				return;
 			}
 		}
 
-		private async UniTask HandleUpgradeForCombo(string comboId, ComboUpgradeConfig upgradeConfig)
+		private async UniTask HandleUpgradeForCombo(string comboId, ComboUpgradeConfig upgradeConfig, DiceScoringService activeScoringService)
 		{
 			if (UnityEngine.Random.value > upgradeConfig.Chance)
 			{
@@ -501,7 +509,7 @@ namespace _Main.Scripts.Dice
 				return;
 			}
 
-			var die = PickUpgradeDie(new StraightUpgradeConfig { Debug = upgradeConfig.Debug, Chance = upgradeConfig.Chance }); // reuse picker
+			var die = PickUpgradeDie();
 			if (die == null)
 			{
 				logger?.LogWarning($"[Upgrade:{comboId}] No dice available for upgrade roll.");
@@ -517,7 +525,7 @@ namespace _Main.Scripts.Dice
 			if (upgradeConfig.Debug)
 			{
 				var weights = die.Weights != null ? string.Join(",", die.Weights) : "null";
-				var outcomes = scoringService.GetComboUpgradeOutcomes(comboId);
+				var outcomes = activeScoringService.GetComboUpgradeOutcomes(comboId);
 				var outcomeTable = outcomes != null
 					? string.Join(", ", outcomes.Select(o => $"{o.Face}:Δmin{o.DeltaMin}/Δmax{o.DeltaMax}/Δb{o.DeltaScoreBonus}"))
 					: "none";
@@ -542,9 +550,9 @@ namespace _Main.Scripts.Dice
 
 			if (comboId == "straight")
 			{
-				var before = scoringService.GetStraightState();
-				var outcome = scoringService.ApplyStraightUpgradeOutcome(rolledFace, logger, null, run);
-				var after = scoringService.GetStraightState();
+				var before = activeScoringService.GetStraightState();
+				var outcome = activeScoringService.ApplyStraightUpgradeOutcome(rolledFace, logger, null, run);
+				var after = activeScoringService.GetStraightState();
 				if (outcome != null)
 				{
 					var summary = $"Rolled {rolledFace}: Min {before.MinLen}->{after.MinLen}, Max {before.MaxLen}->{after.MaxLen}, Bonus {before.ScoreBonus}->{after.ScoreBonus}";
@@ -553,9 +561,9 @@ namespace _Main.Scripts.Dice
 			}
 			else
 			{
-				var before = scoringService.GetComboUpgradeState(comboId);
-				var outcome = scoringService.ApplyGenericUpgradeOutcome(comboId, rolledFace, logger, null, run);
-				var after = scoringService.GetComboUpgradeState(comboId);
+				var before = activeScoringService.GetComboUpgradeState(comboId);
+				var outcome = activeScoringService.ApplyGenericUpgradeOutcome(comboId, rolledFace, logger, null, run);
+				var after = activeScoringService.GetComboUpgradeState(comboId);
 				if (outcome != null && before != null && after != null)
 				{
 					var summary = $"Rolled {rolledFace}: Min {before.Min}->{after.Min}, Max {before.Max}->{after.Max}, Bonus {before.ScoreBonus}->{after.ScoreBonus}";
@@ -578,7 +586,7 @@ namespace _Main.Scripts.Dice
 			}).ToArray();
 		}
 
-		private async UniTask HandleStraightUpgrade(StraightUpgradeConfig upgradeConfig)
+		private async UniTask HandleStraightUpgrade(StraightUpgradeConfig upgradeConfig, DiceScoringService activeScoringService)
 		{
 			if (UnityEngine.Random.value > upgradeConfig.Chance)
 			{
@@ -589,7 +597,7 @@ namespace _Main.Scripts.Dice
 				return;
 			}
 
-			var die = PickUpgradeDie(upgradeConfig);
+			var die = PickUpgradeDie();
 			if (die == null)
 			{
 				logger?.LogWarning("[Upgrade:straight] No dice available for upgrade roll.");
@@ -628,9 +636,9 @@ namespace _Main.Scripts.Dice
 				rolledFace = DiceGameUtils.GetWeightedRandomValue(die.Weights);
 			}
 
-			var before = scoringService.GetStraightState();
-			var outcome = scoringService.ApplyStraightUpgradeOutcome(rolledFace, logger, null, run);
-			var after = scoringService.GetStraightState();
+			var before = activeScoringService.GetStraightState();
+			var outcome = activeScoringService.ApplyStraightUpgradeOutcome(rolledFace, logger, null, run);
+			var after = activeScoringService.GetStraightState();
 			if (outcome != null)
 			{
 				var summary = $"Rolled {rolledFace}: Min {before.MinLen}->{after.MinLen}, Max {before.MaxLen}->{after.MaxLen}, Bonus {before.ScoreBonus}->{after.ScoreBonus}";
@@ -658,15 +666,16 @@ namespace _Main.Scripts.Dice
 				selectedValues[i] = selectedDice[i].CurrentValue;
 			}
 
+			var activeScoringService = diceGameModel.GetCurrentScoringService();
 
-			if (scoringService.HasTrash(selectedValues))
+			if (activeScoringService.HasTrash(selectedValues))
 			{
 				tableModel.SetPreviewPoints(0);
 			}
 			else
 			{
-				var combo = scoringService.Evaluate(selectedValues);
-				tableModel.SetPreviewPoints(scoringService.CalculateTotalScore(combo));
+				var combo = activeScoringService.Evaluate(selectedValues);
+				tableModel.SetPreviewPoints(activeScoringService.CalculateTotalScore(combo));
 			}
 
 

--- a/Assets/_Main/Scripts/DiceGame/Сontrollers/DiceGameProcessController.cs
+++ b/Assets/_Main/Scripts/DiceGame/Сontrollers/DiceGameProcessController.cs
@@ -200,6 +200,16 @@ namespace _Main.Scripts.Dice
 			_ = HandlePassAsync();
 		}
 
+		public async UniTask HandlePassForCurrentTurnAsync()
+		{
+			if (IsProcessing)
+			{
+				return;
+			}
+
+			await HandlePassAsync();
+		}
+
 		private async UniTask HandlePassAsync()
 		{
 			IsProcessing = true;


### PR DESCRIPTION
Сделали два крупных обновления:

1. Разделили состояние игрока и ИИ в DiceGame
- Отдельные runtime-наборы `modifiers/items/scoring` для Player и Enemy.
- Пайплайн `Roll/Pass/RoundEnd` теперь работает через текущую сторону.
- `LevelStart` оставили только для игрока.
- Добавили флаг `enemy_combo_upgrades_enabled` в конфиг и отключение апгрейдов ИИ по нему.
- Выбор кости для апгрейда перевели с `PlayerDiceModelList` на пул текущей стороны.
- Разделили cap-бонусы костей по сторонам (player/enemy), чтобы эффекты не текли между ними.

2. Довели семантику хода ИИ и очистку runtime
- ИИ больше не завершает ход напрямую через `EndTurn(true)`: теперь использует полноценный pass-флоу (`Pass` + `RoundEnd` модификаторы).
- На конец матча добавили явный reset только enemy runtime:
  `EnemyModifierItemsModel`, `EnemyModifiersModel`, enemy cap-бонусы и enemy upgrade state scoring.
- Player runtime оставлен как и был, через инвентарь/ран.
- Дополнительно исправили очистку `ModifiersModel.ClearModifiers()` (убрали двойное удаление).