### PR TITLE
Modifiers Scenario | 137

### DIFF
--- a/Assets/Resources/Json/dice_game_modifiers_schedule.json
+++ b/Assets/Resources/Json/dice_game_modifiers_schedule.json
@@ -1,0 +1,61 @@
+{
+  "id": "default",
+  "default_set_id": "baseline",
+  "sets": {
+    "baseline": {
+      "player_modifiers": [
+        "multiply_combo_three_kind",
+        "shake_reroll",
+        "adjust_ticks_plus1",
+        "pass_activation_multiplier",
+        "extra_dice_cap",
+        "modifier_silencer_item"
+      ],
+      "enemy_modifiers": []
+    },
+    "player_empty_enemy_empty": {
+      "player_modifiers": [],
+      "enemy_modifiers": []
+    },
+    "player_safe_enemy_shake": {
+      "player_modifiers": [
+        "multiply_combo_three_kind"
+      ],
+      "enemy_modifiers": [
+        "shake_reroll"
+      ]
+    }
+  },
+  "by_level": {
+    "1": {
+      "default_set_id": "baseline",
+      "by_day": {
+        "1": {
+          "default_set_id": "baseline",
+          "by_match": {
+            "1": "player_empty_enemy_empty",
+            "2": "player_safe_enemy_shake",
+            "*": "baseline"
+          }
+        },
+        "*": {
+          "default_set_id": "baseline",
+          "by_match": {
+            "*": "baseline"
+          }
+        }
+      }
+    },
+    "*": {
+      "default_set_id": "baseline",
+      "by_day": {
+        "*": {
+          "default_set_id": "baseline",
+          "by_match": {
+            "*": "baseline"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Assets/Resources/Json/dice_game_modifiers_schedule.json.meta
+++ b/Assets/Resources/Json/dice_game_modifiers_schedule.json.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: db9e9b72148d44db961ceaa3258361d0
+timeCreated: 1772376147

--- a/Assets/Resources/Json/dice_game_rules.json
+++ b/Assets/Resources/Json/dice_game_rules.json
@@ -5,6 +5,8 @@
     "min_bet_size": 10,
     "enemy_combo_upgrades_enabled": true,
     "enemy_ai_mode": "scripted",
-    "enemy_ai_scenario_id": ""
+    "enemy_ai_scenario_id": "",
+    "modifiers_mode": "scripted",
+    "modifiers_set_id": ""
   }
 ]

--- a/Assets/_Main/Scripts/Configs/DiceGameConfig.cs
+++ b/Assets/_Main/Scripts/Configs/DiceGameConfig.cs
@@ -9,4 +9,6 @@ public class DiceGameConfig : BaseConfig
 	public bool enemy_combo_upgrades_enabled = true;
 	public string enemy_ai_mode = "heuristic";
 	public string enemy_ai_scenario_id = string.Empty;
+	public string modifiers_mode = "inventory";
+	public string modifiers_set_id = string.Empty;
 }

--- a/Assets/_Main/Scripts/Configs/DiceGameModifiersScheduleConfig.cs
+++ b/Assets/_Main/Scripts/Configs/DiceGameModifiersScheduleConfig.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Collections.Generic;
+
+[Serializable]
+public class DiceGameModifiersScheduleConfig : BaseConfig
+{
+	public const string WildcardKey = "*";
+
+	public string default_set_id = string.Empty;
+	public Dictionary<string, DiceGameModifiersLevelNode> by_level = new();
+	public Dictionary<string, DiceGameModifierSet> sets = new();
+
+	public override void ParseConfig()
+	{
+		by_level ??= new Dictionary<string, DiceGameModifiersLevelNode>();
+		sets ??= new Dictionary<string, DiceGameModifierSet>();
+
+		var levelKeys = new List<string>(by_level.Keys);
+		for (int i = 0; i < levelKeys.Count; i++)
+		{
+			var key = levelKeys[i];
+			if (!by_level.TryGetValue(key, out var node) || node == null)
+			{
+				node = new DiceGameModifiersLevelNode();
+				by_level[key] = node;
+			}
+
+			node.ParseConfig();
+		}
+
+		var setKeys = new List<string>(sets.Keys);
+		for (int i = 0; i < setKeys.Count; i++)
+		{
+			var key = setKeys[i];
+			if (!sets.TryGetValue(key, out var set) || set == null)
+			{
+				set = new DiceGameModifierSet();
+				sets[key] = set;
+			}
+
+			set.ParseConfig();
+		}
+	}
+
+	public bool TryValidateStatic(out string error)
+	{
+		if (string.IsNullOrWhiteSpace(default_set_id))
+		{
+			error = "[DiceGameModifiersSchedule] default_set_id is required.";
+			return false;
+		}
+
+		if (!sets.ContainsKey(default_set_id))
+		{
+			error = $"[DiceGameModifiersSchedule] default_set_id '{default_set_id}' is missing in sets.";
+			return false;
+		}
+
+		foreach (var pair in by_level)
+		{
+			if (!IsValidAxisKey(pair.Key))
+			{
+				error = $"[DiceGameModifiersSchedule] Invalid level key '{pair.Key}'. Use positive integer or '*'.";
+				return false;
+			}
+
+			if (pair.Value == null)
+			{
+				error = $"[DiceGameModifiersSchedule] Level node '{pair.Key}' is null.";
+				return false;
+			}
+
+			if (!pair.Value.TryValidateStatic(pair.Key, sets, out error))
+			{
+				return false;
+			}
+		}
+
+		error = null;
+		return true;
+	}
+
+	public bool TryResolveSet(int level, int day, int match, out DiceGameModifierSet set)
+	{
+		set = null;
+
+		var orderedLevelKeys = new[] { level.ToString(), WildcardKey };
+		for (int i = 0; i < orderedLevelKeys.Length; i++)
+		{
+			if (!by_level.TryGetValue(orderedLevelKeys[i], out var levelNode) || levelNode == null)
+			{
+				continue;
+			}
+
+			if (levelNode.TryResolve(day, match, sets, out set))
+			{
+				return true;
+			}
+		}
+
+		return sets.TryGetValue(default_set_id, out set) && set != null;
+	}
+
+	private static bool IsValidAxisKey(string key)
+	{
+		if (string.IsNullOrWhiteSpace(key))
+		{
+			return false;
+		}
+
+		if (string.Equals(key, WildcardKey, StringComparison.Ordinal))
+		{
+			return true;
+		}
+
+		return int.TryParse(key, out var value) && value > 0;
+	}
+}
+
+[Serializable]
+public class DiceGameModifiersLevelNode
+{
+	public string default_set_id = string.Empty;
+	public Dictionary<string, DiceGameModifiersDayNode> by_day = new();
+
+	public void ParseConfig()
+	{
+		by_day ??= new Dictionary<string, DiceGameModifiersDayNode>();
+		var keys = new List<string>(by_day.Keys);
+		for (int i = 0; i < keys.Count; i++)
+		{
+			var key = keys[i];
+			if (!by_day.TryGetValue(key, out var node) || node == null)
+			{
+				node = new DiceGameModifiersDayNode();
+				by_day[key] = node;
+			}
+
+			node.ParseConfig();
+		}
+	}
+
+	public bool TryValidateStatic(string levelKey, IReadOnlyDictionary<string, DiceGameModifierSet> sets, out string error)
+	{
+		if (!string.IsNullOrWhiteSpace(default_set_id) && !sets.ContainsKey(default_set_id))
+		{
+			error = $"[DiceGameModifiersSchedule] Level '{levelKey}' default_set_id '{default_set_id}' is missing in sets.";
+			return false;
+		}
+
+		foreach (var pair in by_day)
+		{
+			if (!IsValidAxisKey(pair.Key))
+			{
+				error = $"[DiceGameModifiersSchedule] Invalid day key '{pair.Key}' in level '{levelKey}'. Use positive integer or '*'.";
+				return false;
+			}
+
+			if (pair.Value == null)
+			{
+				error = $"[DiceGameModifiersSchedule] Day node '{pair.Key}' in level '{levelKey}' is null.";
+				return false;
+			}
+
+			if (!pair.Value.TryValidateStatic(levelKey, pair.Key, sets, out error))
+			{
+				return false;
+			}
+		}
+
+		error = null;
+		return true;
+	}
+
+	public bool TryResolve(int day, int match, IReadOnlyDictionary<string, DiceGameModifierSet> sets, out DiceGameModifierSet set)
+	{
+		set = null;
+		var orderedDayKeys = new[] { day.ToString(), DiceGameModifiersScheduleConfig.WildcardKey };
+		for (int i = 0; i < orderedDayKeys.Length; i++)
+		{
+			if (!by_day.TryGetValue(orderedDayKeys[i], out var dayNode) || dayNode == null)
+			{
+				continue;
+			}
+
+			if (dayNode.TryResolve(match, sets, out set))
+			{
+				return true;
+			}
+		}
+
+		return !string.IsNullOrWhiteSpace(default_set_id)
+		       && sets.TryGetValue(default_set_id, out set)
+		       && set != null;
+	}
+
+	private static bool IsValidAxisKey(string key)
+	{
+		if (string.IsNullOrWhiteSpace(key))
+		{
+			return false;
+		}
+
+		if (string.Equals(key, DiceGameModifiersScheduleConfig.WildcardKey, StringComparison.Ordinal))
+		{
+			return true;
+		}
+
+		return int.TryParse(key, out var value) && value > 0;
+	}
+}
+
+[Serializable]
+public class DiceGameModifiersDayNode
+{
+	public string default_set_id = string.Empty;
+	public Dictionary<string, string> by_match = new();
+
+	public void ParseConfig()
+	{
+		by_match ??= new Dictionary<string, string>();
+	}
+
+	public bool TryValidateStatic(
+		string levelKey,
+		string dayKey,
+		IReadOnlyDictionary<string, DiceGameModifierSet> sets,
+		out string error)
+	{
+		if (!string.IsNullOrWhiteSpace(default_set_id) && !sets.ContainsKey(default_set_id))
+		{
+			error = $"[DiceGameModifiersSchedule] Level '{levelKey}', day '{dayKey}' default_set_id '{default_set_id}' is missing in sets.";
+			return false;
+		}
+
+		foreach (var pair in by_match)
+		{
+			if (!IsValidAxisKey(pair.Key))
+			{
+				error = $"[DiceGameModifiersSchedule] Invalid match key '{pair.Key}' in level '{levelKey}', day '{dayKey}'. Use positive integer or '*'.";
+				return false;
+			}
+
+			if (string.IsNullOrWhiteSpace(pair.Value))
+			{
+				error = $"[DiceGameModifiersSchedule] Empty set id for match key '{pair.Key}' in level '{levelKey}', day '{dayKey}'.";
+				return false;
+			}
+
+			if (!sets.ContainsKey(pair.Value))
+			{
+				error = $"[DiceGameModifiersSchedule] Set id '{pair.Value}' for match key '{pair.Key}' in level '{levelKey}', day '{dayKey}' is missing in sets.";
+				return false;
+			}
+		}
+
+		error = null;
+		return true;
+	}
+
+	public bool TryResolve(int match, IReadOnlyDictionary<string, DiceGameModifierSet> sets, out DiceGameModifierSet set)
+	{
+		set = null;
+
+		if (by_match.TryGetValue(match.ToString(), out var exactSetId)
+		    && !string.IsNullOrWhiteSpace(exactSetId)
+		    && sets.TryGetValue(exactSetId, out set)
+		    && set != null)
+		{
+			return true;
+		}
+
+		if (by_match.TryGetValue(DiceGameModifiersScheduleConfig.WildcardKey, out var wildcardSetId)
+		    && !string.IsNullOrWhiteSpace(wildcardSetId)
+		    && sets.TryGetValue(wildcardSetId, out set)
+		    && set != null)
+		{
+			return true;
+		}
+
+		return !string.IsNullOrWhiteSpace(default_set_id)
+		       && sets.TryGetValue(default_set_id, out set)
+		       && set != null;
+	}
+
+	private static bool IsValidAxisKey(string key)
+	{
+		if (string.IsNullOrWhiteSpace(key))
+		{
+			return false;
+		}
+
+		if (string.Equals(key, DiceGameModifiersScheduleConfig.WildcardKey, StringComparison.Ordinal))
+		{
+			return true;
+		}
+
+		return int.TryParse(key, out var value) && value > 0;
+	}
+}
+
+[Serializable]
+public class DiceGameModifierSet
+{
+	public string[] player_modifiers = Array.Empty<string>();
+	public string[] enemy_modifiers = Array.Empty<string>();
+
+	public void ParseConfig()
+	{
+		player_modifiers ??= Array.Empty<string>();
+		enemy_modifiers ??= Array.Empty<string>();
+	}
+}
+
+public static class DiceGameModifiersMode
+{
+	public const string Inventory = "inventory";
+	public const string Scripted = "scripted";
+}

--- a/Assets/_Main/Scripts/Configs/DiceGameModifiersScheduleConfig.cs.meta
+++ b/Assets/_Main/Scripts/Configs/DiceGameModifiersScheduleConfig.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c50b6e1a71d34844abc47dcfcd2cbeda
+timeCreated: 1772376147

--- a/Assets/_Main/Scripts/Configs/EnemyAiScenarioConfig.cs
+++ b/Assets/_Main/Scripts/Configs/EnemyAiScenarioConfig.cs
@@ -56,7 +56,7 @@ public class EnemyAiScenarioConfig : BaseConfig
 
 		if (enemy_setup.use_modifiers)
 		{
-			error = $"Scenario '{id}': enemy_setup.use_modifiers must be false (modifiers are disabled for scripted AI).";
+			error = $"Scenario '{id}': enemy_setup.use_modifiers is deprecated. Configure modifiers via dice_game_rules.modifiers_mode and dice_game_modifiers_schedule.json.";
 			return false;
 		}
 

--- a/Assets/_Main/Scripts/Core/Services/Config.meta
+++ b/Assets/_Main/Scripts/Core/Services/Config.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: 9a2baaf7e4284a08962d421f1a3a3d50
-timeCreated: 1767568960

--- a/Assets/_Main/Scripts/DiceGame/Сontrollers/DiceGameGlobalController.cs
+++ b/Assets/_Main/Scripts/DiceGame/Сontrollers/DiceGameGlobalController.cs
@@ -34,6 +34,7 @@ namespace _Main.Scripts.Dice
 		private readonly SceneContext sceneContext;
 		private const string EnemyAiScenariosResourcePath = "Json/enemy_ai_scenarios";
 		private const string EnemyAiScenarioScheduleResourcePath = "Json/enemy_ai_scenario_schedule";
+		private const string DiceGameModifiersScheduleResourcePath = "Json/dice_game_modifiers_schedule";
 
 		private DiceView[] playerDiceViewsArray;
 		private DiceView[] enemyDiceViewsArray;
@@ -198,7 +199,12 @@ namespace _Main.Scripts.Dice
 			var baseCap = Mathf.Min(6, CouplePositionsHandler.FirstPosArray.Length, CouplePositionsHandler.SecondPosArray.Length);
 			diceGameModel.SetBaseMaxDiceCount(baseCap);
 			diceTableView.SwitchTurn(diceGameModel.IsPlayerTurn);
-			return await SetupEnemyAiScenarioAsync(diceGameConfig);
+			if (!await SetupEnemyAiScenarioAsync(diceGameConfig))
+			{
+				return false;
+			}
+
+			return await SetupModifiersAsync(diceGameConfig);
 		}
 		
 		private async UniTask DiceGamePersistentControllers()
@@ -649,6 +655,159 @@ namespace _Main.Scripts.Dice
 			}
 
 			return defaults;
+		}
+
+		private async UniTask<bool> SetupModifiersAsync(DiceGameConfig diceGameConfig)
+		{
+			var modifiersMode = diceGameConfig.modifiers_mode?.Trim();
+			if (string.IsNullOrWhiteSpace(modifiersMode))
+			{
+				modifiersMode = DiceGameModifiersMode.Inventory;
+			}
+
+			if (string.Equals(modifiersMode, DiceGameModifiersMode.Inventory, StringComparison.OrdinalIgnoreCase))
+			{
+				return await ApplyInventoryModifiersAsync();
+			}
+
+			if (string.Equals(modifiersMode, DiceGameModifiersMode.Scripted, StringComparison.OrdinalIgnoreCase))
+			{
+				return await ApplyModifiersScheduleAsync(diceGameConfig.modifiers_set_id);
+			}
+
+			FailDiceGameSetup(
+				$"[DiceGame] Unsupported modifiers_mode '{diceGameConfig.modifiers_mode}'. Expected '{DiceGameModifiersMode.Inventory}' or '{DiceGameModifiersMode.Scripted}'.");
+			return false;
+		}
+
+		private UniTask<bool> ApplyInventoryModifiersAsync()
+		{
+			// Keep player's inventory-driven modifiers intact in default mode.
+			diceGameModel.EnemyModifierItemsModel.Reset();
+			return UniTask.FromResult(true);
+		}
+
+		private async UniTask<bool> ApplyModifiersScheduleAsync(string setIdOverride)
+		{
+			var schedule = await configService.GetFirstOrDefaultAsync<DiceGameModifiersScheduleConfig>(DiceGameModifiersScheduleResourcePath);
+			if (schedule == null)
+			{
+				FailDiceGameSetup($"[DiceGame] Modifiers schedule '{DiceGameModifiersScheduleResourcePath}' not found.");
+				return false;
+			}
+
+			schedule.ParseConfig();
+			if (!schedule.TryValidateStatic(out var validationError))
+			{
+				FailDiceGameSetup($"[DiceGame] Modifiers schedule validation failed: {validationError}");
+				return false;
+			}
+
+			DiceGameModifierSet resolvedSet = null;
+			var overrideSetId = setIdOverride?.Trim();
+			if (!string.IsNullOrWhiteSpace(overrideSetId))
+			{
+				if (!schedule.sets.TryGetValue(overrideSetId, out resolvedSet) || resolvedSet == null)
+				{
+					FailDiceGameSetup(
+						$"[DiceGame] modifiers_set_id override '{overrideSetId}' not found in schedule '{DiceGameModifiersScheduleResourcePath}'.");
+					return false;
+				}
+			}
+			else
+			{
+				var level = run.Level + 1;
+				var day = run.Day + 1;
+				var match = run.Tick + 1;
+				if (!schedule.TryResolveSet(level, day, match, out resolvedSet) || resolvedSet == null)
+				{
+					FailDiceGameSetup($"[DiceGame] Modifiers schedule could not resolve set for level={level}, day={day}, match={match}.");
+					return false;
+				}
+			}
+
+			var catalog = await configService.GetConfigsAsync<ItemCatalogEntry>(ResourcePaths.Json.items_catalog);
+			if (!ApplyModifierSetToSide(
+				    resolvedSet.player_modifiers,
+				    diceGameModel.PlayerModifierItemsModel,
+				    diceGameModel.PlayerScoringService,
+				    catalog,
+				    "player"))
+			{
+				return false;
+			}
+
+			if (!ApplyModifierSetToSide(
+				    resolvedSet.enemy_modifiers,
+				    diceGameModel.EnemyModifierItemsModel,
+				    diceGameModel.EnemyScoringService,
+				    catalog,
+				    "enemy"))
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		private bool ApplyModifierSetToSide(
+			string[] modifierIds,
+			ModifierItemsModel itemsModel,
+			DiceScoringService scoringService,
+			IReadOnlyDictionary<string, ItemCatalogEntry> catalog,
+			string sideLabel)
+		{
+			if (itemsModel == null)
+			{
+				FailDiceGameSetup($"[DiceGame] {sideLabel} modifier model is missing.");
+				return false;
+			}
+
+			itemsModel.Reset();
+			if (modifierIds == null || modifierIds.Length == 0)
+			{
+				return true;
+			}
+
+			var uniqueIds = new HashSet<string>();
+			for (int i = 0; i < modifierIds.Length; i++)
+			{
+				var modifierId = modifierIds[i]?.Trim();
+				if (string.IsNullOrWhiteSpace(modifierId))
+				{
+					FailDiceGameSetup($"[DiceGame] Empty modifier id in {sideLabel}_modifiers.");
+					return false;
+				}
+
+				if (!uniqueIds.Add(modifierId))
+				{
+					FailDiceGameSetup($"[DiceGame] Duplicate modifier id '{modifierId}' in {sideLabel}_modifiers.");
+					return false;
+				}
+
+				if (!catalog.TryGetValue(modifierId, out var entry))
+				{
+					FailDiceGameSetup($"[DiceGame] Modifier '{modifierId}' for {sideLabel} not found in items_catalog.");
+					return false;
+				}
+
+				if (entry.typeEnum != ItemCatalogType.Modifier)
+				{
+					FailDiceGameSetup($"[DiceGame] Item '{modifierId}' for {sideLabel} is not a Modifier.");
+					return false;
+				}
+
+				var item = ModifierItemFactory.Create(entry, scoringService);
+				if (item == null)
+				{
+					FailDiceGameSetup($"[DiceGame] Failed to create modifier '{modifierId}' for {sideLabel}.");
+					return false;
+				}
+
+				itemsModel.AddItem(item);
+			}
+
+			return true;
 		}
 
 		private void FailDiceGameSetup(string message)

--- a/D6-Express.slnx
+++ b/D6-Express.slnx
@@ -6,10 +6,10 @@
   <Project Path="PlatformCore.csproj" />
   <Project Path="LineworkLite.csproj" />
   <Project Path="UniTask.Addressables.csproj" />
+  <Project Path="Assembly-CSharp-Editor.csproj" />
   <Project Path="FMODUnityResonanceEditor.csproj" />
   <Project Path="FMODUnityEditor.csproj" />
   <Project Path="DOTween.Modules.csproj" />
-  <Project Path="Assembly-CSharp-Editor.csproj" />
   <Project Path="FMODUnity.csproj" />
   <Project Path="MackySoft.SerializeReferenceExtensions.Editor.csproj" />
   <Project Path="LineworkLite.Editor.csproj" />


### PR DESCRIPTION

- Добавлен единый конфиг сценариев модификаторов: `Assets/Resources/Json/dice_game_modifiers_schedule.json`.
- Реализована модель расписания `DiceGameModifiersScheduleConfig` с map-структурой:
  - `sets` (наборы модификаторов для `player`/`enemy`)
  - `by_level -> by_day -> by_match` + `*` wildcard и `default_set_id`.
- В общий конфиг игры (`dice_game_rules`) добавлены поля:
  - `modifiers_mode` (`inventory` или `scripted`)
  - `modifiers_set_id` (опциональный override набора без учета level/day/match).
- В `DiceGameGlobalController` добавено применение модификаторов на старте матча:
  - `inventory`: оставляет модификаторы игрока из инвентаря, очищает врага.
  - `scripted`: применяет набор из расписания (или по `modifiers_set_id`) отдельно для игрока и врага.
- Добавлена строгая валидация scripted-режима (существование set/id, корректный тип `Modifier`, отсутствие пустых/дублирующихся id), при ошибке — fail setup.
- Поле `enemy_setup.use_modifiers` в AI-сценариях помечено как deprecated: управление модификаторами перенесено в общий конфиг + расписание.