### PR TITLE
Add force cursor lock toggle on K hotkey

### DIFF
--- a/Assets/PlatformCore/Services/UI/Cursor/CursorService.cs
+++ b/Assets/PlatformCore/Services/UI/Cursor/CursorService.cs
@@ -35,10 +35,7 @@ namespace PlatformCore.Services.UI
 		{
 			if (TryLock())
 			{
-				Cursor.lockState = CursorLockMode.Locked;
-				Cursor.visible = false;
-				_uiCursorView.Show();
-				OnCursorStateChanged?.Invoke();
+				ApplyLockedState();
 			}
 		}
 
@@ -46,16 +43,56 @@ namespace PlatformCore.Services.UI
 		{
 			if (TryUnlock())
 			{
-				Cursor.lockState = CursorLockMode.None;
-				Cursor.visible = true;
-				_uiCursorView.Hide();
-				OnCursorStateChanged?.Invoke();
+				ApplyUnlockedState();
+			}
+		}
+
+
+
+		public void ForceToggleCursor()
+		{
+			if (IsCursorLocked)
+			{
+				ForceUnlockCursor();
+			}
+			else
+			{
+				ForceLockCursor();
 			}
 		}
 
 		public void Dispose()
 		{
 			UnlockCursor();
+		}
+
+
+		private void ForceLockCursor()
+		{
+			lockCount = 1;
+			ApplyLockedState();
+		}
+
+		private void ForceUnlockCursor()
+		{
+			lockCount = 0;
+			ApplyUnlockedState();
+		}
+
+		private void ApplyLockedState()
+		{
+			Cursor.lockState = CursorLockMode.Locked;
+			Cursor.visible = false;
+			_uiCursorView.Show();
+			OnCursorStateChanged?.Invoke();
+		}
+
+		private void ApplyUnlockedState()
+		{
+			Cursor.lockState = CursorLockMode.None;
+			Cursor.visible = true;
+			_uiCursorView.Hide();
+			OnCursorStateChanged?.Invoke();
 		}
 
 		private bool TryLock()

--- a/Assets/PlatformCore/Services/UI/Cursor/ICursorService.cs
+++ b/Assets/PlatformCore/Services/UI/Cursor/ICursorService.cs
@@ -7,6 +7,7 @@ namespace PlatformCore.Services.UI
 		public event Action OnCursorStateChanged;
 		void LockCursor();
 		void UnlockCursor();
+		void ForceToggleCursor();
 		bool IsCursorLocked { get; }
 	}
 }

--- a/Assets/_Main/Scripts/Core/GameRoot.cs
+++ b/Assets/_Main/Scripts/Core/GameRoot.cs
@@ -185,6 +185,7 @@ namespace _Main.Scripts.Core
 			controllersList.AddRange(new IBaseController[]
 			{
 				new CashBalanceNotificationController(playerModel.InventoryModel, notificationService),
+				new CursorHotkeyController(cursorService),
 				debugController,
 				speechController,
 				new QuestsViewController(uiService, playerModel.Quests, factory, game),

--- a/Assets/_Main/Scripts/Debug/CursorHotkeyController.cs
+++ b/Assets/_Main/Scripts/Debug/CursorHotkeyController.cs
@@ -1,0 +1,38 @@
+using PlatformCore.Core;
+using PlatformCore.Infrastructure.Lifecycle;
+using PlatformCore.Services.UI;
+using UnityEngine;
+
+public class CursorHotkeyController : IBaseController, IActivatable, IUpdatable
+{
+	private readonly ICursorService cursorService;
+	private bool isActive;
+
+	public CursorHotkeyController(ICursorService cursorService)
+	{
+		this.cursorService = cursorService;
+	}
+
+	public void Activate()
+	{
+		isActive = true;
+	}
+
+	public void Deactivate()
+	{
+		isActive = false;
+	}
+
+	public void OnUpdate(float deltaTime)
+	{
+		if (!isActive)
+		{
+			return;
+		}
+
+		if (Input.GetKeyDown(KeyCode.K))
+		{
+			cursorService.ForceToggleCursor();
+		}
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a global hotkey to force-lock/unlock the in-game cursor on `K` regardless of existing lock reference counts.
- Allow quick developer/debug control of cursor state that bypasses the normal accumulated `lockCount` semantics.

### Description
- Added `void ForceToggleCursor()` to the `ICursorService` interface to expose a forced toggle API.
- Implemented `ForceToggleCursor()`, `ForceLockCursor()`, `ForceUnlockCursor()`, and helper methods `ApplyLockedState()` / `ApplyUnlockedState()` in `CursorService` so forced state changes reset `lockCount` and apply the cursor state immediately.
- Introduced `CursorHotkeyController` which implements `IActivatable`/`IUpdatable` and calls `cursorService.ForceToggleCursor()` when `Input.GetKeyDown(KeyCode.K)` is detected in `OnUpdate`.
- Registered `CursorHotkeyController` in `GameRoot` controllers list so the hotkey is active within the game lifecycle.

### Testing
- Searched repository for new symbols with `rg "ForceToggleCursor|CursorHotkeyController" Assets` and verified matches exist (success).
- Ran `git diff --check` to ensure no whitespace or diff issues (success).
- Ran `git status --short` to confirm changed files were staged/committed (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1640adb9c832d95e8b7cd81bb73f4)