### PR TITLE
Add force-toggle cursor hotkey and refactor CursorService state handling

### DIFF
--- a/Assets/PlatformCore/Services/UI/Cursor/CursorService.cs
+++ b/Assets/PlatformCore/Services/UI/Cursor/CursorService.cs
@@ -35,10 +35,7 @@ namespace PlatformCore.Services.UI
 		{
 			if (TryLock())
 			{
-				Cursor.lockState = CursorLockMode.Locked;
-				Cursor.visible = false;
-				_uiCursorView.Show();
-				OnCursorStateChanged?.Invoke();
+				ApplyLockedState();
 			}
 		}
 
@@ -46,16 +43,56 @@ namespace PlatformCore.Services.UI
 		{
 			if (TryUnlock())
 			{
-				Cursor.lockState = CursorLockMode.None;
-				Cursor.visible = true;
-				_uiCursorView.Hide();
-				OnCursorStateChanged?.Invoke();
+				ApplyUnlockedState();
+			}
+		}
+
+
+
+		public void ForceToggleCursor()
+		{
+			if (IsCursorLocked)
+			{
+				ForceUnlockCursor();
+			}
+			else
+			{
+				ForceLockCursor();
 			}
 		}
 
 		public void Dispose()
 		{
 			UnlockCursor();
+		}
+
+
+		private void ForceLockCursor()
+		{
+			lockCount = 1;
+			ApplyLockedState();
+		}
+
+		private void ForceUnlockCursor()
+		{
+			lockCount = 0;
+			ApplyUnlockedState();
+		}
+
+		private void ApplyLockedState()
+		{
+			Cursor.lockState = CursorLockMode.Locked;
+			Cursor.visible = false;
+			_uiCursorView.Show();
+			OnCursorStateChanged?.Invoke();
+		}
+
+		private void ApplyUnlockedState()
+		{
+			Cursor.lockState = CursorLockMode.None;
+			Cursor.visible = true;
+			_uiCursorView.Hide();
+			OnCursorStateChanged?.Invoke();
 		}
 
 		private bool TryLock()

--- a/Assets/PlatformCore/Services/UI/Cursor/ICursorService.cs
+++ b/Assets/PlatformCore/Services/UI/Cursor/ICursorService.cs
@@ -7,6 +7,7 @@ namespace PlatformCore.Services.UI
 		public event Action OnCursorStateChanged;
 		void LockCursor();
 		void UnlockCursor();
+		void ForceToggleCursor();
 		bool IsCursorLocked { get; }
 	}
 }

--- a/Assets/_Main/Scripts/Core/GameRoot.cs
+++ b/Assets/_Main/Scripts/Core/GameRoot.cs
@@ -185,6 +185,7 @@ namespace _Main.Scripts.Core
 			controllersList.AddRange(new IBaseController[]
 			{
 				new CashBalanceNotificationController(playerModel.InventoryModel, notificationService),
+				new CursorHotkeyController(inputService, cursorService),
 				debugController,
 				speechController,
 				new QuestsViewController(uiService, playerModel.Quests, factory, game),

--- a/Assets/_Main/Scripts/Debug/CursorHotkeyController.cs
+++ b/Assets/_Main/Scripts/Debug/CursorHotkeyController.cs
@@ -1,0 +1,31 @@
+using _Main.Scripts.Core.Services;
+using PlatformCore.Core;
+using PlatformCore.Infrastructure.Lifecycle;
+using PlatformCore.Services.UI;
+
+public class CursorHotkeyController : IBaseController, IActivatable
+{
+	private readonly IInputService inputService;
+	private readonly ICursorService cursorService;
+
+	public CursorHotkeyController(IInputService inputService, ICursorService cursorService)
+	{
+		this.inputService = inputService;
+		this.cursorService = cursorService;
+	}
+
+	public void Activate()
+	{
+		inputService.OnJumpPressed += OnJumpPressed;
+	}
+
+	public void Deactivate()
+	{
+		inputService.OnJumpPressed -= OnJumpPressed;
+	}
+
+	private void OnJumpPressed()
+	{
+		cursorService.ForceToggleCursor();
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a simple hotkey to force the cursor to toggle for debugging and input workflows by exposing a force-toggle API. 
- Simplify and centralize cursor state changes inside `CursorService` to avoid duplicated logic when locking/unlocking the cursor.

### Description
- Added `ForceToggleCursor()` to `ICursorService` and implemented it in `CursorService` as well as helper methods `ForceLockCursor`, `ForceUnlockCursor`, `ApplyLockedState`, and `ApplyUnlockedState` to centralize state application. 
- Updated `LockCursor()` and `UnlockCursor()` to call the new `Apply*State` helpers instead of duplicating the cursor state logic. 
- Added `CursorHotkeyController` which listens to `inputService.OnJumpPressed` and calls `cursorService.ForceToggleCursor()`. 
- Registered `CursorHotkeyController` in `GameRoot` controller list so the hotkey is active at runtime.

### Testing
- Project compiles successfully after the changes. 
- Existing automated unit tests were run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1640adb9c832d95e8b7cd81bb73f4)