### PR TITLE
196 ужасная путаница между предметами и модификаторами в коде

### DIFF
--- a/Assets/Resources/Json/items_catalog.json
+++ b/Assets/Resources/Json/items_catalog.json
@@ -133,67 +133,67 @@
   },
   {
     "id": "extra_dice_cap",
-    "type": "Modifier",
+    "type": "ModifierItem",
     "nameKey": "modifier_extra_dice_cap_title",
     "descriptionKey": "modifier_extra_dice_cap_description",
     "rarity": "Uncommon",
     "price": 20,
     "visualId": "ExtraDiceCapItem",
     "data": {
-      "modifierType": "ExtraDiceCapItem",
+      "itemType": "ExtraDiceCapItem",
       "bonus": 4
     }
   },
   {
     "id": "modifier_silencer_item",
-    "type": "Modifier",
+    "type": "ModifierItem",
     "nameKey": "modifier_silencer_item_title",
     "descriptionKey": "modifier_silencer_item_description",
     "rarity": "Rare",
     "price": 25,
     "visualId": "ModifierSilencerItem",
     "data": {
-      "modifierType": "ModifierSilencerItem",
+      "itemType": "ModifierSilencerItem",
       "cooldownPasses": 2
     }
   },
   {
     "id": "pass_multiplier_item",
-    "type": "Modifier",
+    "type": "ModifierItem",
     "nameKey": "modifier_pass_multiplier_item_title",
     "descriptionKey": "modifier_pass_multiplier_item_description",
     "rarity": "Rare",
     "price": 20,
     "visualId": "PassMultiplierItem",
     "data": {
-      "modifierType": "PassMultiplierItem",
+      "itemType": "PassMultiplierItem",
       "scoreMultiplier": 1.5,
       "activationsPerDay": 1
     }
   },
   {
     "id": "reroll_selected_item",
-    "type": "Modifier",
+    "type": "ModifierItem",
     "nameKey": "modifier_reroll_selected_item_title",
     "descriptionKey": "modifier_reroll_selected_item_description",
     "rarity": "Uncommon",
     "price": 15,
     "visualId": "RerollSelectedItem",
     "data": {
-      "modifierType": "RerollSelectedItem",
+      "itemType": "RerollSelectedItem",
       "cooldownPasses": 2
     }
   },
   {
     "id": "step_up_item",
-    "type": "Modifier",
+    "type": "ModifierItem",
     "nameKey": "modifier_step_up_item_title",
     "descriptionKey": "modifier_step_up_item_description",
     "rarity": "Rare",
     "price": 18,
     "visualId": "StepUpItem",
     "data": {
-      "modifierType": "StepUpItem",
+      "itemType": "StepUpItem",
       "selectionCount": 3,
       "cooldownPasses": 3
     }

--- a/Assets/Resources/Json/player.json
+++ b/Assets/Resources/Json/player.json
@@ -8,5 +8,5 @@
     "default",
     "default"
   ],
-  "modifiers": []
+  "modifierItems": []
 }

--- a/Assets/_Main/Scripts/Configs/Items/ItemCatalogEntry.cs
+++ b/Assets/_Main/Scripts/Configs/Items/ItemCatalogEntry.cs
@@ -28,9 +28,9 @@ public class ItemCatalogEntry : BaseConfig
             {
                 typeEnum = ItemCatalogType.Dice;
             }
-            else if (string.Equals(normalized, "Modifier", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(normalized, "ModifierItem", StringComparison.OrdinalIgnoreCase))
             {
-                typeEnum = ItemCatalogType.Modifier;
+                typeEnum = ItemCatalogType.ModifierItem;
             }
             else
             {
@@ -102,5 +102,5 @@ public enum ItemCatalogType
 {
     Unknown,
     Dice,
-    Modifier
+    ModifierItem
 }

--- a/Assets/_Main/Scripts/Configs/PlayerConfig.cs
+++ b/Assets/_Main/Scripts/Configs/PlayerConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 [Serializable]
 public class PlayerConfig : BaseConfig
@@ -6,4 +7,17 @@ public class PlayerConfig : BaseConfig
 	public int cash;
 	public string[] dices;
 	public string[] modifierItems;
+
+	[JsonProperty("modifiers")]
+	private string[] legacyModifiers;
+
+	public override void ParseConfig()
+	{
+		dices ??= Array.Empty<string>();
+
+		if (modifierItems == null)
+		{
+			modifierItems = legacyModifiers ?? Array.Empty<string>();
+		}
+	}
 }

--- a/Assets/_Main/Scripts/Configs/PlayerConfig.cs
+++ b/Assets/_Main/Scripts/Configs/PlayerConfig.cs
@@ -5,5 +5,5 @@ public class PlayerConfig : BaseConfig
 {
 	public int cash;
 	public string[] dices;
-	public string[] modifiers;
+	public string[] modifierItems;
 }

--- a/Assets/_Main/Scripts/Core/Services/GameAnalyticsService.cs
+++ b/Assets/_Main/Scripts/Core/Services/GameAnalyticsService.cs
@@ -54,7 +54,7 @@ namespace _Main.Scripts.Core.Services
 		public void TrackShopPurchase(string shopId, TradeItem tradeItem)
 		{
 			var shopValue = NormalizeEventPart(shopId);
-			var itemTypeValue = NormalizeEventPart(tradeItem.ItemType.ToString());
+			var itemTypeValue = MapShopItemType(tradeItem.ItemType);
 			var itemIdValue = NormalizeEventPart(tradeItem.ItemId);
 
 			GameAnalytics.NewDesignEvent(
@@ -113,6 +113,20 @@ namespace _Main.Scripts.Core.Services
 				.Replace(" ", "_")
 				.Replace(":", "_")
 				.Replace("/", "_");
+		}
+
+		private static string MapShopItemType(ItemCatalogType itemType)
+		{
+			switch (itemType)
+			{
+				case ItemCatalogType.Dice:
+					return "dice";
+				case ItemCatalogType.ModifierItem:
+					// Keep legacy analytics dimension stable after enum rename.
+					return "modifier";
+				default:
+					return UnknownValue;
+			}
 		}
 
 		private static string FormatLevel(int level)

--- a/Assets/_Main/Scripts/Debug/DebugWindowPlayer.cs
+++ b/Assets/_Main/Scripts/Debug/DebugWindowPlayer.cs
@@ -35,7 +35,7 @@ public class DebugWindowPlayer : DebugWindowModel
 
 		catalog = await configService.GetConfigsAsync<ItemCatalogEntry>(ResourcePaths.Json.items_catalog);
 		diceIds = catalog.Where(x => x.Value.typeEnum == ItemCatalogType.Dice).Select(x => x.Key).ToArray();
-		modifierIds = catalog.Where(x => x.Value.typeEnum == ItemCatalogType.Modifier).Select(x => x.Key).ToArray();
+		modifierIds = catalog.Where(x => x.Value.typeEnum == ItemCatalogType.ModifierItem).Select(x => x.Key).ToArray();
 	}
 
 	public DebugWindowPlayer(Run run, PlayerModel playerModel, PlayerView playerView, ConfigService configService, GlobalNotificationService notificationService)

--- a/Assets/_Main/Scripts/DiceGame/Items/ModifierItemsSyncController.cs
+++ b/Assets/_Main/Scripts/DiceGame/Items/ModifierItemsSyncController.cs
@@ -68,7 +68,7 @@ namespace _Main.Scripts.Dice
 				return;
 			}
 
-			if (entry.typeEnum != ItemCatalogType.Modifier)
+			if (entry.typeEnum != ItemCatalogType.ModifierItem)
 			{
 				return;
 			}

--- a/Assets/_Main/Scripts/DiceGame/Modifiers/ModifierItemFactory.cs
+++ b/Assets/_Main/Scripts/DiceGame/Modifiers/ModifierItemFactory.cs
@@ -10,21 +10,21 @@ namespace _Main.Scripts.Dice
 
 		public static IModifierItem Create(ItemCatalogEntry entry, DiceScoringService scoringService)
 		{
-			if (entry == null || entry.typeEnum != ItemCatalogType.Modifier)
+			if (entry == null || entry.typeEnum != ItemCatalogType.ModifierItem)
 			{
 				return null;
 			}
 
 			var data = entry.data;
-			var modifierType = data?["modifierType"]?.ToString();
-			if (string.IsNullOrEmpty(modifierType))
+			var itemType = data?["itemType"]?.ToString();
+			if (string.IsNullOrEmpty(itemType))
 			{
 				return null;
 			}
 
 			var prefab = LoadItemPrefab(entry);
 
-			switch (modifierType)
+			switch (itemType)
 			{
 				case nameof(ExtraDiceCapItem):
 				{

--- a/Assets/_Main/Scripts/DiceGame/Modifiers/ModifiersViewController.cs
+++ b/Assets/_Main/Scripts/DiceGame/Modifiers/ModifiersViewController.cs
@@ -79,7 +79,7 @@ public class ModifiersViewController : BaseContextController<UIModifiersView>
             return;
         }
 
-        if (!configs.TryGetValue(modifierItem.Id, out var config) || config.typeEnum != ItemCatalogType.Modifier)
+        if (!configs.TryGetValue(modifierItem.Id, out var config) || config.typeEnum != ItemCatalogType.ModifierItem)
         {
             return;
         }

--- a/Assets/_Main/Scripts/DiceGame/Modifiers/ModifiersViewMiniController.cs
+++ b/Assets/_Main/Scripts/DiceGame/Modifiers/ModifiersViewMiniController.cs
@@ -97,7 +97,7 @@ public class ModifiersViewMiniController : IActivatable, IPreloadable
             return;
         }
 
-        if (!configs.TryGetValue(modifierItem.Id, out var config) || config.typeEnum != ItemCatalogType.Modifier)
+        if (!configs.TryGetValue(modifierItem.Id, out var config) || config.typeEnum != ItemCatalogType.ModifierItem)
         {
             return;
         }

--- a/Assets/_Main/Scripts/DiceGame/Сontrollers/DiceTooltipsController.cs
+++ b/Assets/_Main/Scripts/DiceGame/Сontrollers/DiceTooltipsController.cs
@@ -192,7 +192,7 @@ namespace _Main.Scripts.Dice
 				return;
 			}
 
-			if (!catalog.TryGetValue(item.Id, out var entry) || entry.typeEnum != ItemCatalogType.Modifier)
+			if (!catalog.TryGetValue(item.Id, out var entry) || entry.typeEnum != ItemCatalogType.ModifierItem)
 			{
 				return;
 			}

--- a/Assets/_Main/Scripts/Game/RunController.cs
+++ b/Assets/_Main/Scripts/Game/RunController.cs
@@ -81,9 +81,9 @@ public class RunController : IBaseController, IActivatable, IPreloadable
 		}
 
 		playerModel.InventoryModel.RemoveAllModifierItems();
-		if (playerConfig.modifiers != null)
+		if (playerConfig.modifierItems != null)
 		{
-			foreach (var modifierId in playerConfig.modifiers)
+			foreach (var modifierId in playerConfig.modifierItems)
 			{
 				playerModel.InventoryModel.AddModifierItem(modifierId);
 			}

--- a/Assets/_Main/Scripts/Notifications/ModifierAppliedNotificationController.cs
+++ b/Assets/_Main/Scripts/Notifications/ModifierAppliedNotificationController.cs
@@ -71,7 +71,7 @@ public class ModifierAppliedNotificationController : IBaseController, IActivatab
 	{
 		if (modifier is IModifierItem item)
 		{
-			if (catalog != null && catalog.TryGetValue(item.Id, out var entry) && entry.typeEnum == ItemCatalogType.Modifier)
+			if (catalog != null && catalog.TryGetValue(item.Id, out var entry) && entry.typeEnum == ItemCatalogType.ModifierItem)
 			{
 				return localizationService != null ? localizationService.GetLocalized(entry.nameKey) : entry.nameKey;
 			}

--- a/Assets/_Main/Scripts/Shop/Shop.cs
+++ b/Assets/_Main/Scripts/Shop/Shop.cs
@@ -197,7 +197,7 @@ public class Shop : IGameStateChanger
                 case ItemCatalogType.Dice:
                     inventoryModel.AddDice(tradeItem.ItemId);
                     break;
-                case ItemCatalogType.Modifier:
+                case ItemCatalogType.ModifierItem:
                     inventoryModel.AddModifierItem(tradeItem.ItemId);
                     break;
             }

--- a/Assets/_Main/Scripts/Shop/Shop.cs
+++ b/Assets/_Main/Scripts/Shop/Shop.cs
@@ -124,6 +124,13 @@ public class Shop : IGameStateChanger
                 continue;
             }
 
+            if (!IsSupportedShopItemType(entry.typeEnum))
+            {
+                UnityEngine.Debug.LogError(
+                    $"[Shop] Catalog entry '{entry.id}' has unsupported item type '{entry.typeEnum}' and will be skipped.");
+                continue;
+            }
+
             var weight = GetRarityWeight(entry.rarityEnum);
             result.Add(new ShopCandidate(entry, weight));
         }
@@ -188,30 +195,46 @@ public class Shop : IGameStateChanger
 
     private void OnBuyed(TradeItem tradeItem)
     {
-        if (inventoryModel.CashCount >= tradeItem.Price)
-        {
-            inventoryModel.TakeCash(tradeItem.Price);
-
-            switch (tradeItem.ItemType)
-            {
-                case ItemCatalogType.Dice:
-                    inventoryModel.AddDice(tradeItem.ItemId);
-                    break;
-                case ItemCatalogType.ModifierItem:
-                    inventoryModel.AddModifierItem(tradeItem.ItemId);
-                    break;
-            }
-
-            tradeItem.Buyed -= OnBuyed;
-            var index = Array.IndexOf(tradeItems, tradeItem);
-            tradeItems[index] = null;
-            ItemRemoved?.Invoke(index, tradeItem);
-
-            BuyCompleted?.Invoke(tradeItem);
-        }
-        else
+        if (inventoryModel.CashCount < tradeItem.Price)
         {
             BuyFailed?.Invoke();
+            return;
+        }
+
+        switch (tradeItem.ItemType)
+        {
+            case ItemCatalogType.Dice:
+                inventoryModel.TakeCash(tradeItem.Price);
+                inventoryModel.AddDice(tradeItem.ItemId);
+                break;
+            case ItemCatalogType.ModifierItem:
+                inventoryModel.TakeCash(tradeItem.Price);
+                inventoryModel.AddModifierItem(tradeItem.ItemId);
+                break;
+            default:
+                UnityEngine.Debug.LogError(
+                    $"[Shop] Unsupported purchase type '{tradeItem.ItemType}' for item '{tradeItem.ItemId}'. Purchase aborted.");
+                BuyFailed?.Invoke();
+                return;
+        }
+
+        tradeItem.Buyed -= OnBuyed;
+        var index = Array.IndexOf(tradeItems, tradeItem);
+        tradeItems[index] = null;
+        ItemRemoved?.Invoke(index, tradeItem);
+
+        BuyCompleted?.Invoke(tradeItem);
+    }
+
+    private static bool IsSupportedShopItemType(ItemCatalogType itemType)
+    {
+        switch (itemType)
+        {
+            case ItemCatalogType.Dice:
+            case ItemCatalogType.ModifierItem:
+                return true;
+            default:
+                return false;
         }
     }
 


### PR DESCRIPTION
**Что сделано в этом PR**

1. Развели понятия `modifier` (глобальная механика) и `modifier item` (предмет из инвентаря/shop) в контракте каталога:
- `items_catalog.json`: `type: "Modifier"` -> `type: "ModifierItem"`, `data.modifierType` -> `data.itemType`  

2. Обновили типизацию и парсинг каталога:
- `ItemCatalogType.Modifier` -> `ItemCatalogType.ModifierItem`
- парсинг `type` теперь ожидает `ModifierItem`  
3. Синхронизировали потребителей каталога на новый тип:
- shop-покупка
- item-sync
- tooltip/mini/full modifiers UI
- notifications
- debug окно  

4. Устранили риски регрессии после миграции:
- shop теперь фильтрует unsupported/`Unknown` типы и не списывает деньги при некорректном типе  

**Что сознательно не меняли**
- Глобальные модификаторы и их расписание (`dice_game_modifiers_schedule.json`) оставлены без изменений.
- Нейминг локализационных ключей вида `modifier_*_item_*` пока сохранён (как договорились).

closes #196 